### PR TITLE
add pre handler for route and subroute

### DIFF
--- a/__tests__/RouterFactory.test.js
+++ b/__tests__/RouterFactory.test.js
@@ -225,6 +225,58 @@ describe('RouterFactory', () => {
     });
   });
 
+  describe('_registerPreHandlers', () => {
+    it('Should not change routerArgs if no pre handlers defined', () => {
+      const factory = new RouterFactory({});
+
+      const routerArgs = [];
+
+      factory._registerPreHandlers(routerArgs, null);
+
+      expect(routerArgs).toEqual([]);
+    });
+
+    it('Should register handler if single handler defined', () => {
+      const factory = new RouterFactory({});
+      factory.routeUtil = {
+        getHandlerWithManagedNextCall: jest.fn().mockReturnValue(123)
+      };
+      const routerArgs = [];
+      const handler = (req, res) => {};
+      factory._registerPreHandlers(routerArgs, handler);
+
+      expect(routerArgs).toEqual([123]);
+      expect(
+        factory.routeUtil.getHandlerWithManagedNextCall
+      ).toHaveBeenCalledWith(handler);
+    });
+
+    it('Should register handler if array of handlers defined', () => {
+      const factory = new RouterFactory({});
+      factory.routeUtil = {
+        getHandlerWithManagedNextCall: jest.fn().mockReturnValue(123)
+      };
+      const routerArgs = [];
+      const handlers = [
+        (req, res) => {
+          return 1;
+        },
+        (req, res) => {
+          return 2;
+        }
+      ];
+      factory._registerPreHandlers(routerArgs, handlers);
+
+      expect(routerArgs).toEqual([123, 123]);
+      expect(
+        factory.routeUtil.getHandlerWithManagedNextCall
+      ).toHaveBeenCalledWith(handlers[0]);
+      expect(
+        factory.routeUtil.getHandlerWithManagedNextCall
+      ).toHaveBeenCalledWith(handlers[1]);
+    });
+  });
+
   describe('_registerSubroute', () => {
     it('Should register subroute with middleware properly', () => {
       const factory = new RouterFactory({});

--- a/src/RouterFactory.js
+++ b/src/RouterFactory.js
@@ -101,6 +101,19 @@ module.exports = class RouterFactory {
     this._setFileUploadValidationMiddleware(validationSchema, routerArgs);
   }
 
+  _registerPreHandlers(routerArgs, handler) {
+    if (!handler) return;
+
+    if (Array.isArray(handler)) {
+      const nextAdjustedMiddleware = handler.map((m) =>
+        this.routeUtil.getHandlerWithManagedNextCall(m)
+      );
+      routerArgs.push(...nextAdjustedMiddleware);
+    } else {
+      routerArgs.push(this.routeUtil.getHandlerWithManagedNextCall(handler));
+    }
+  }
+
   _registerRoute(
     router,
     {
@@ -109,10 +122,13 @@ module.exports = class RouterFactory {
       controller,
       validationSchema = null,
       authorizer = null,
-      middleware = null
+      middleware = null,
+      pre = null
     }
   ) {
     const routerArgs = [path];
+
+    this._registerPreHandlers(routerArgs, pre);
 
     this._registerMiddleware(routerArgs, {
       validationSchema,
@@ -132,10 +148,13 @@ module.exports = class RouterFactory {
       router: subrouter,
       authorizer,
       validationSchema = null,
-      middleware = []
+      middleware = [],
+      pre = null
     }
   ) {
     const routerArgs = [path];
+
+    this._registerPreHandlers(routerArgs, pre);
 
     this._registerMiddleware(routerArgs, {
       validationSchema,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,25 +113,26 @@ export declare interface ValidationSchema {
   }
 }
 
-interface ResponseMap {
+interface SwaggerResponseMap {
   [key: number]: object;
 }
 
 export declare interface SwaggerEndpointDoc {
   description?: string;
   summary?: string;
-  responses?: ResponseMap;
+  responses?: SwaggerResponseMap;
   tags?: string[];
 }
 
 type AuthorizerType = Handler | Handler[] | string | string[] | object | object[];
 
-export declare interface IRouteParams {
+export declare interface RouteParams {
   controller: string | Handler | typeof BaseController;
   validationSchema?: ValidationSchema;
   authorizer?: AuthorizerType;
   doc?: SwaggerEndpointDoc;
   middleware?: Handler[];
+  pre?: Handler | Handler[];
 }
 
 export declare type RouteMethod =
@@ -143,81 +144,82 @@ export declare type RouteMethod =
   | 'patch'
   | 'options';
 
-export declare interface IEndpoint extends IRouteParams {
+export declare interface Endpoint extends RouteParams {
   method: RouteMethod;
   path: string;
 }
 
-export declare type IRouteProps = Omit<IRouteParams, 'controller'>;
+export declare type RouteProps = Omit<RouteParams, 'controller'>;
 
 export declare class Route {
   static get(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static get(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static get(path: string, params?: RouteParams): Endpoint;
 
   static post(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static post(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static post(path: string, params?: RouteParams): Endpoint;
 
   static delete(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static delete(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static delete(path: string, params?: RouteParams): Endpoint;
 
   static put(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static put(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static put(path: string, params?: RouteParams): Endpoint;
 
   static head(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static head(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static head(path: string, params?: RouteParams): Endpoint;
 
   static options(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static options(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static options(path: string, params?: RouteParams): Endpoint;
 
   static patch(
     path: string,
     controller: string | Handler | typeof BaseController,
-    params?: IRouteProps
-  ): IEndpoint;
-  static patch(path: string, params?: IRouteParams): IEndpoint;
+    params?: RouteProps
+  ): Endpoint;
+  static patch(path: string, params?: RouteParams): Endpoint;
 }
 
-export declare interface ISubroute {
+export declare interface Subroute {
   path: string;
   router: ExpressiveRouter;
   authorizer?: AuthorizerType;
   middleware?: Handler[];
   validationSchema?: ValidationSchema;
+  pre?: Handler | Handler[];
 }
 
 export declare function subroute(
   path: string,
   router: ExpressiveRouter,
-  options: Pick<ISubroute, 'authorizer' | 'middleware' | 'validationSchema'>
-): ISubroute
+  options: Pick<Subroute, 'authorizer' | 'middleware' | 'validationSchema'>
+): Subroute
 
 export declare interface ExpressiveRouter {
-  routes?: IEndpoint[];
-  subroutes?: ISubroute[];
+  routes?: Endpoint[];
+  subroutes?: Subroute[];
 }
 
 export type SwaggerSecurityDefinitions = {

--- a/ts-example/src/routers/helloRouter/index.ts
+++ b/ts-example/src/routers/helloRouter/index.ts
@@ -26,7 +26,10 @@ const postHello = Route.post('/hello', {
     } else {
       next();
     }
-  }
+  },
+  pre: [(req, res) => {
+    console.log('pre', req.url); // do work here before any middleware or routes are registered
+  }]
 });
 
 export const helloRouter: ExpressiveRouter = {


### PR DESCRIPTION
add a 'pre' option in Route params to run handlers before all middleware. The option is available for both Route and Subroute params.

e.g. 
```javascript
Route.get('/hello', {
  controller: someFn,
  pre: somePreHandlerFn, // runs before all internal middleware
}
```

Equivalent to 

```javascript
router.get('/hello', somePreHandlerFn, ...)
```